### PR TITLE
Use `phrase_from_stream` to parse JSON-RPC requests

### DIFF
--- a/prolog/lsp_utils.pl
+++ b/prolog/lsp_utils.pl
@@ -7,7 +7,8 @@
                       clause_variable_positions/3,
                       seek_to_line/2,
                       linechar_offset/3,
-                      url_path/2
+                      url_path/2,
+                      unlimited//1
                      ]).
 /** <module> LSP Utils
 
@@ -380,3 +381,10 @@ find_containing_term(Offset, [Dict|_], [DP|_], Term, P) :-
     find_containing_term(Offset, [Value], [ValuePos], Term, P).
 find_containing_term(Offset, [_|Ts], [_|Ps], T, P) :-
     find_containing_term(Offset, Ts, Ps, T, P).
+
+:- meta_predicate unlimited(//, *, *).
+
+unlimited(Nonterminal) -->
+    call(Nonterminal),
+    unlimited(Nonterminal).
+


### PR DESCRIPTION
It looks like I got `phrase_from_stream/2` to work with `lsp_request//1`!

I had noticed that even though my first attempt caused `phrase_from_stream/2` to hang, the call to `json_read_dict/3` did succeed, which means parsing the first request did complete. Since `phrase_from_stream/2` doesn't know when to expect the end of stream, I wrapped the call in `unlimited//1` which is essentially an infinite loop. Declaratively it makes sense too, since we're not trying to parse a single request, but an infinite stream of them.

Remaining issues: I had to remove the `set_stream(In/Out, encoding(_))` calls in order for this to work in the `stdio` server on Windows, so this is a proof of concept for now until/unless the encoding issue can be pinned down.

Speaking of which, do you know of a good way to *test* the incorrect `Content-Length` problems which caused you to add the `set_stream/2` calls? I'd like to start seeing if there's a way to compute `Content-Length` correctly even without setting stream encodings.