### PR TITLE
Ensure Capabilities is grounded before extracting TextSettings

### DIFF
--- a/prolog/lsp_server.pl
+++ b/prolog/lsp_server.pl
@@ -230,7 +230,8 @@ handle_msg("initialize", Msg,
     retractall(client_encoding(_)),
     assertz(client_encoding(Encoding)),
     % Get hover format capabilities
-    ( ( get_dict(textDocument, Capabilities, TextSettings),
+    ( ( get_dict(capabilities, Params, Capabilities),
+        get_dict(textDocument, Capabilities, TextSettings),
         get_dict(hover, TextSettings, HoverSettings),
         get_dict(contentFormat, HoverSettings, HoverFormats),
         memberchk("markdown", HoverFormats) )

--- a/test/refactor.plt
+++ b/test/refactor.plt
@@ -26,8 +26,8 @@ test('Renaming predicate across project',
                                            range: @{end: @{character:42, line:0},
                                                     start: @{character:24, line:0}}}],
                              ServerUri-[@{newText:handle_document_changes,
-                                          range: @{end: @{character:22, line:381},
-                                                   start: @{character:4, line:381}}},
+                                          range: @{end: @{character:22, line:382},
+                                                   start: @{character:4, line:382}}},
                                         @{newText:handle_document_changes,
                                           range: @{end: @{character:51, line:29},
                                                    start: @{character:33, line:29}}}]] ) ]) :-
@@ -41,23 +41,23 @@ test('Renaming predicate across project',
     directory_source_files(ProjectDir, ProjectFiles, [recursive(true), if(true)]),
     forall(member(F, ProjectFiles), assertz(lsp_source:loaded_source(F))),
     % fragile here - change line/char to be on ⤵ 'handle_doc_changes' in handle_msg/3 clause for didChange
-    rename_at_location(ServerUri, line_char(382, 11), 'handle_document_changes', Edits),
+    rename_at_location(ServerUri, line_char(383, 11), 'handle_document_changes', Edits),
     dict_pairs(Edits, _, EditsPairs).
 
 test('Renaming a variable in predicate',
      [ true( EditsPairs =@= [ServerUri-[@{newText:'Message',
-                                          range: @{end: @{character:37, line:336},
-                                                   start: @{character:34, line:336}}},
+                                          range: @{end: @{character:37, line:337},
+                                                   start: @{character:34, line:337}}},
                                         @{newText:'Message',
-                                          range: @{end: @{character:36, line:337},
-                                                   start: @{character:33, line:337}}}]]) ])  :-
+                                          range: @{end: @{character:36, line:338},
+                                                   start: @{character:33, line:338}}}]]) ])  :-
     context_module(ThisModule),
     module_property(ThisModule, file(ThisFile)),
     relative_file_name(ProjectDir, ThisFile, '../prolog'),
     directory_file_path(ProjectDir, 'lsp_server.pl', ServerFile),
     url_path(ServerUri, ServerFile),
     % fragile here - change line/char to be on ⤵ 'Msg' in handle_msg/3 clause for textDocument/rename
-    rename_at_location(ServerUri, line_char(337, 34), 'Message', Edits),
+    rename_at_location(ServerUri, line_char(338, 34), 'Message', Edits),
     dict_pairs(Edits, _, EditsPairs).
 
 


### PR DESCRIPTION
vim-lsc plugin doesn't send `capabilities.general` to the LSP server. In this case `client_encoding` is filled by default value and `Capabilities` variable is not grounded. As a result `get_dict` call in hover format capabilities section fails.